### PR TITLE
Added new command to sort packageAliases in sfdx-project.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ A plugin for SFDX CLI to help update `sfdx-project.json` with package versions i
 
 4. Link the plugin: `sfdx plugins:link` .
 
-## Command
+## Commands
 
-`sfdx bummer:package:versions:retrieve`
+### `sfdx bummer:package:aliases:sort`
+
+Sorts `packageAliases` in `sfdx-project.json`, based on each package's name, major version, minor version, patch version, and build number
+
+### `sfdx bummer:package:versions:retrieve`
 
 Scans the `packageAliases` in `sfdx-project.json`, and retrieves package versions for any packages listed. All 3 parameters are optional
 

--- a/messages/bummer.json
+++ b/messages/bummer.json
@@ -1,4 +1,5 @@
 {
+    "sortCommandDescription": "Sorts the list of package aliases in sfdx-project.json",
     "retrieveCommandDescription": "Retrieves package versions from your devhub, based on packages listed in sfdx-project.json",
     "retrieveCommandMaxVersionsFlagDescription": "Controls how many package versions are retrieved per package",
     "retrieveCommandReleasedFlagDescription": "Controls if only released package versions are included"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@jongpie/sfdx-bummer-plugin",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@jongpie/sfdx-bummer-plugin",
-    "description": "A plugin for SFDX CLI to help update sfdx-project.json with package versions in your devhub.",
-    "version": "0.0.16",
+    "description": "A plugin for SFDX CLI to help maintain sfdx-project.json",
+    "version": "0.0.17",
     "author": "Jonathan Gillespie",
     "bugs": {
         "url": "https://github.com/jongpie/sfdx-bummer-plugin/issues"
@@ -43,6 +43,9 @@
         "commands": "./lib/commands",
         "bin": "sfdx",
         "topics": {
+            "bummer:package:aliases:sort": {
+                "description": "Sorts the list of package aliases in sfdx-project.json"
+            },
             "bummer:package:versions:retrieve": {
                 "description": "Retrieves package versions from your devhub and updates sfdx-project.json"
             }

--- a/src/commands/bummer/package/aliases/sort.ts
+++ b/src/commands/bummer/package/aliases/sort.ts
@@ -1,0 +1,82 @@
+import { SfdxCommand } from '@salesforce/command';
+import { Messages, SfdxError } from '@salesforce/core';
+import * as fs from 'fs';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@jongpie/sfdx-bummer-plugin', 'bummer');
+
+export default class Sort extends SfdxCommand {
+    public static description = messages.getMessage('sortCommandDescription');
+    public static examples = [`$ sfdx bummer:package:aliases:sort`];
+
+    protected static requiresProject = true;
+
+    public async run() {
+        const project = await this.project.resolveProjectConfig();
+        if (project.packageAliases === undefined) {
+            throw new SfdxError(`Could not find 'packageAliases' in sfdx-project.json`);
+        }
+
+        const sortedPackageAliases = Object.keys(project.packageAliases)
+            // Use a custom sort function so that multiple attributes can be checked for sorting
+            .sort((firstItem, secondItem) => {
+                const firstPackage = this.convertToObject(firstItem);
+                const secondPackage = this.convertToObject(secondItem);
+                const propertiesToCheck = ['name', 'majorVersion', 'minorVersion', 'patchVersion', 'buildNumber'];
+                for (let i = 0; i < propertiesToCheck.length; i++) {
+                    // Prep the data
+                    const propertyName = propertiesToCheck[i];
+                    const firstValue = isNaN(firstPackage[propertyName] as any) ? firstPackage[propertyName] : Number(firstPackage[propertyName]);
+                    const secondValue = isNaN(secondPackage[propertyName] as any) ? secondPackage[propertyName] : Number(secondPackage[propertyName]);
+
+                    // Compare the data
+                    if ((!firstValue && !!secondValue) || firstValue < secondValue) {
+                        return -1;
+                    } else if ((!!firstValue && !secondValue) || firstValue > secondValue) {
+                        return 1;
+                    }
+                }
+                return 0;
+            })
+            .reduce(function (result, key) {
+                // Copy the sorted key-value pairs to the new result object
+                result[key] = project.packageAliases[key];
+                return result;
+            }, {});
+
+        project.packageAliases = sortedPackageAliases;
+
+        this.saveProject(project);
+    }
+
+    private convertToObject(packageAlias) {
+        // Expected formats for alias:
+        // some package
+        // some package@1.2.3-99
+        // some package@1.2.3-99-some-description-or-name-or-something
+        let aliasPieces = [packageAlias.split('@')[0]];
+        if (packageAlias.split('@').length > 1) {
+            aliasPieces = aliasPieces.concat(packageAlias.split('@')[1].replace('-', '.').split('.'));
+        }
+
+        return {
+            name: aliasPieces[0],
+            majorVersion: aliasPieces[1],
+            minorVersion: aliasPieces[2],
+            patchVersion: aliasPieces[3],
+            buildNumber: aliasPieces[4]?.includes('-') ? aliasPieces[4].split('-')[0] : aliasPieces[4]
+        };
+    }
+
+    private saveProject(project) {
+        if (project.defaultdevhubusername) {
+            delete project.defaultdevhubusername;
+        }
+        if (project.defaultusername) {
+            delete project.defaultusername;
+        }
+        const outputPath = 'sfdx-project.json';
+        this.ux.log(`Saving changes to ${outputPath}`);
+        fs.writeFileSync(outputPath, JSON.stringify(project, null, 4));
+    }
+}

--- a/src/commands/bummer/package/versions/retrieve.ts
+++ b/src/commands/bummer/package/versions/retrieve.ts
@@ -114,6 +114,7 @@ export default class Retrieve extends SfdxCommand {
         }
         return cleanedPackageAliases;
     }
+
     private generatePackageVersionAlias(packageAlias, packageVersion) {
         let packageVersionAlias =
             packageAlias +


### PR DESCRIPTION
New command `bummer:package:aliases:sort` can now be used to sort the node of `packageAliases`. This command breaks up the alias into several pieces:

- Package name
- Major number (if it's a package version)
- Minor number (if it's a package version)
- Patch number (if it's a package version)
- Build number (if it's a package version)

Each property is then used in the sorting logic - it iterates over each of the properties until a difference is found. It also converts the numeric values to be handled as numbers so that they're properly sorted (e.g., "16" is sorted _after_ "6", etc.)