### PR TITLE
Suppress now deprecated (?) restDeploy property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@jongpie/sfdx-bummer-plugin",
     "description": "A plugin for SFDX CLI to help maintain sfdx-project.json",
-    "version": "0.0.17",
+    "version": "0.0.18",
     "author": "Jonathan Gillespie",
     "bugs": {
         "url": "https://github.com/jongpie/sfdx-bummer-plugin/issues"

--- a/src/commands/bummer/package/aliases/sort.ts
+++ b/src/commands/bummer/package/aliases/sort.ts
@@ -75,6 +75,9 @@ export default class Sort extends SfdxCommand {
         if (project.defaultusername) {
             delete project.defaultusername;
         }
+        if (project.restDeploy) {
+            delete project.restDeploy;
+        }
         const outputPath = 'sfdx-project.json';
         this.ux.log(`Saving changes to ${outputPath}`);
         fs.writeFileSync(outputPath, JSON.stringify(project, null, 4));

--- a/src/commands/bummer/package/aliases/sort.ts
+++ b/src/commands/bummer/package/aliases/sort.ts
@@ -69,15 +69,12 @@ export default class Sort extends SfdxCommand {
     }
 
     private saveProject(project) {
-        if (project.defaultdevhubusername) {
-            delete project.defaultdevhubusername;
-        }
-        if (project.defaultusername) {
-            delete project.defaultusername;
-        }
-        if (project.restDeploy) {
-            delete project.restDeploy;
-        }
+        const deleteConfig = ["defaultdevhubusername", "defaultusername", "restDeploy"];
+        deleteConfig.forEach((configKey : string) => {
+            if (project[configKey]) {
+                delete project[configKey]
+            }
+        })
         const outputPath = 'sfdx-project.json';
         this.ux.log(`Saving changes to ${outputPath}`);
         fs.writeFileSync(outputPath, JSON.stringify(project, null, 4));


### PR DESCRIPTION
Plugin works like a charm but I noticed I have this prop being returned by the base `resolveProjectConfig` call, and the existing linting on `sfdx-project.json` informs me that property is no longer supported (awkward) so ...