### PR TITLE
Updated sort.ts to remove more problematic properties from sfdx-project.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@jongpie/sfdx-bummer-plugin",
     "description": "A plugin for SFDX CLI to help maintain sfdx-project.json",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "author": "Jonathan Gillespie",
     "bugs": {
         "url": "https://github.com/jongpie/sfdx-bummer-plugin/issues"

--- a/src/commands/bummer/package/aliases/sort.ts
+++ b/src/commands/bummer/package/aliases/sort.ts
@@ -71,7 +71,12 @@ export default class Sort extends SfdxCommand {
     private saveProject(project) {
         // TODO long term, this still needs to be revisited to determine why these extra properties appear in the first place
         // It seems to be caused by calling this.project.resolveProjectConfig() (above)
-        const deleteConfig = ["defaultdevhubusername", "defaultusername", "restDeploy", 'target-dev-hub'];
+        const deleteConfig = [
+            // Older sfdx properties that shouldn't be included
+            "defaultdevhubusername", "defaultusername", "restDeploy",
+            // Newer sf properties that shouldn't be included
+            "disable-telemetry", "org-metadata-rest-deploy", "target-dev-hub", "target-org"
+        ];
         deleteConfig.forEach((configKey : string) => {
             if (project[configKey]) {
                 delete project[configKey]

--- a/src/commands/bummer/package/aliases/sort.ts
+++ b/src/commands/bummer/package/aliases/sort.ts
@@ -69,7 +69,9 @@ export default class Sort extends SfdxCommand {
     }
 
     private saveProject(project) {
-        const deleteConfig = ["defaultdevhubusername", "defaultusername", "restDeploy"];
+        // TODO long term, this still needs to be revisited to determine why these extra properties appear in the first place
+        // It seems to be caused by calling this.project.resolveProjectConfig() (above)
+        const deleteConfig = ["defaultdevhubusername", "defaultusername", "restDeploy", 'target-dev-hub'];
         deleteConfig.forEach((configKey : string) => {
             if (project[configKey]) {
                 delete project[configKey]


### PR DESCRIPTION
When using `SfdxCommand`'s function `this.project.resolveProjectConfig()`, additional properties are added to the in-memory representation of `sfdx-project.json`. Previously, I already had a list of extra properties to delete before saving `sfdx-project.json`. This PR removes some new-ish properties from the JSON:

- `disable-telemetry`
- `org-metadata-rest-deploy`
- `target-dev-hub`
- `target-org`

Long term, there's probably a much better way to deal with this, and this plugin should eventually be converted to an `sf` plugin (instead of using the legacy `sfdx` plugin framework). But this PR should hopefully work as a quick fix for this issue.